### PR TITLE
Include readme.md in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include readme.md


### PR DESCRIPTION
Currently, you can only install from wheels but for a conda package, we would like to use the sdist.