### PR TITLE
Show help on empty command, remove build docs

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -41,24 +41,16 @@ Options:
   --help                          Show this message and exit.
 ```
 
-## `build`     
-
-Builds static html files so you may view a dashboard.
-
-```text
-Options:
-  --help  Show this message and exit.
-```
-
 ## `serve`     
 
-Serves the skedulord dashboard.
+Serves the Skedulord API (and webapp if built).
 
 ```text
 Options:
-  --build / --no-build  Build the site beforehand?  [default: True]
-  --port INTEGER        How many rows should the table show.  [default: 8000]
-  --help                Show this message and exit.
+  --host TEXT     The host to bind.  [default: 127.0.0.1]
+  --port INTEGER  The port number to use.  [default: 8000]
+  --reload        Enable auto-reload.  [default: False]
+  --help          Show this message and exit.
 ```
 ## `wipe`      
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,16 +29,13 @@ will also be the name of the folder where logs can be found.
 /Users/vincent/.skedulord/
 ├── heartbeat.jsonl
 ├── jobname1
-│   ├── 2021-02-14T16:56:34.html
 │   └── 2021-02-14T16:56:34.txt
 └── jobname2
-    ├── 2021-02-14T16:56:35.html
     └── 2021-02-14T16:56:35.txt
 
 ```
 
-The logs themselves have a timestamp as the filename. There are basic `.txt` logs 
-but also fancy `.html` logs which render nicely in a dashboard.
+The logs themselves have a timestamp as the filename.
 
 ## Mechanics 
 
@@ -103,29 +100,16 @@ python -m skedulord history
 This history command has many query parameters that makes it easy for you to find the 
 logs of the jobs that failed.
 
-## Dashboard 
+## Webapp
 
-If you want, you can even use skedulord to run a small dashboard for you. It's nice and 
-minimal as to not to distract you. 
+Skedulord ships a FastAPI backend and a React webapp.
 
 ```python
 python -m skedulord serve
 ```
 
-The landing page shows an overview of all jobs. 
-
-![](dashboard1.png)
-
-You can click on the associated link to find all runs.
-
-![](dashboard2.png)
-
-From here you can explore the logs. We host both the raw .txt logs
-and a "fancy" variant that attemps some syntax highlighting.
-
-![](dashboard3.png)
-
-If you'd like to play around, we host a small demo of this dashboard [here](https://koaning.github.io/skedulord-demo/).
+The frontend lives in `webapp/` and can be run via `npm install` + `npm run dev`.
+If you run `npm run build`, the API will serve the built app from `webapp/dist`.
 
 ## Shutting Down 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,12 +17,10 @@ Options:
   --help  Show this message and exit.
 
 Commands:
-  build     Builds static html files so you may view a dashboard.
   history   Shows a table with job status.
   run       Run a single command, which is logged by skedulord.
   schedule  Set (or reset) cron jobs based on config.
-  serve     Opens the dashboard in a browser.
+  serve     Serves the Skedulord API (and webapp if built).
   version   Show the version.
   wipe      Wipe the disk or schedule state.
 ```
-

--- a/readme.md
+++ b/readme.md
@@ -35,9 +35,7 @@ Commands:
   schedule  Set (or reset) cron jobs based on config.
   run       Run a single command, which is logged by skedulord.
   history   Shows a table with job status.
-  summary   Shows a summary of all jobs.
-  build     Builds static html files so you may view a dashboard.
-  serve     Opens the dashboard in a browser.
+  serve     Serves the Skedulord API (and webapp if built).
   wipe      Wipe the disk or schedule state.
   version   Show the version.
 ```
@@ -139,37 +137,13 @@ Schedule commands support a few runtime tokens that are rendered when a job star
 - `{current_time}` (ISO time)
 - `{current_datetime}` (ISO datetime)
 
-### Dashboard 
+### Webapp
 
-We are migrating to a new webapp built with React + Radix + shadcn and a FastAPI
-backend. For now, you can start the API via:
+Skedulord ships a FastAPI backend and a React webapp. You can start the API via:
 
 ```text
 python -m skedulord serve
 ```
 
-The frontend lives in `webapp/` and can be run via `npm install` + `npm run dev`
-once dependencies are installed.
-
-If you want, you can even use skedulord to run a small dashboard for you to show
-all the logs from past jobs. These are all available from the terminal as well, 
-but it's nice to have an extra interface.
-
-```python
-python -m skedulord serve
-```
-
-The landing page shows an overview of all jobs. 
-
-![](docs/dashboard1.png)
-
-You can click on the associated link to find all runs.
-
-![](docs/dashboard2.png)
-
-From here you can explore the logs. We host both the raw .txt logs
-and a "fancy" variant that attemps some syntax highlighting.
-
-![](docs/dashboard3.png)
-
-If you'd like to play around, we host a small demo of this dashboard [here](https://koaning.github.io/skedulord-demo/).
+The frontend lives in `webapp/` and can be run via `npm install` + `npm run dev`.
+If you run `npm run build`, the API will serve the built app from `webapp/dist`.

--- a/skedulord/__main__.py
+++ b/skedulord/__main__.py
@@ -14,13 +14,20 @@ from skedulord.common import SKEDULORD_PATH
 from skedulord.cron import Cron, clean_cron, parse_job_from_settings
 from skedulord.db import fetch_runs
 from skedulord.templating import render_tokens
-from skedulord.dashboard import build_site
 
 app = typer.Typer(
     name="SKEDULORD",
     add_completion=False,
     help="SKEDULORD: helps with cronjobs and logs.",
+    invoke_without_command=True,
 )
+
+
+@app.callback(invoke_without_command=True)
+def main(ctx: typer.Context):
+    """Show help if no command is provided."""
+    if ctx.invoked_subcommand is None:
+        typer.echo(ctx.get_help())
 
 
 @app.command()
@@ -111,14 +118,6 @@ def history(
             d["logpath"],
         )
     print(table)
-
-
-@app.command(name="build")
-def build():
-    """
-    Builds static html files so you may view a dashboard after.
-    """
-    build_site()
 
 
 @app.command(name="serve")


### PR DESCRIPTION
Show Typer help when no subcommand is provided. Remove the obsolete build command and update docs to match the current API/webapp flow.