### PR TITLE
Add auth-backed users and login UI

### DIFF
--- a/skedulord/__main__.py
+++ b/skedulord/__main__.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -9,10 +10,11 @@ from rich.table import Table
 from clumper import Clumper
 
 from skedulord import __version__ as lord_version
+from skedulord.auth import hash_password
 from skedulord.job import JobRunner
 from skedulord.common import SKEDULORD_PATH
 from skedulord.cron import Cron, clean_cron, parse_job_from_settings
-from skedulord.db import fetch_runs
+from skedulord.db import delete_user, fetch_runs, fetch_user, insert_user, update_user_password
 from skedulord.templating import render_tokens
 from skedulord.dashboard import build_site
 
@@ -21,6 +23,80 @@ app = typer.Typer(
     add_completion=False,
     help="SKEDULORD: helps with cronjobs and logs.",
 )
+
+users_app = typer.Typer(help="Manage users for the API/dashboard.")
+app.add_typer(users_app, name="users")
+
+
+@users_app.command("add")
+def add_user(
+    username: str = typer.Option(..., "--username", help="Username to add."),
+    password: str = typer.Option(
+        None,
+        "--password",
+        help="Password for the user (prompted if omitted).",
+    ),
+):
+    """Create a new user."""
+    if fetch_user(username):
+        print(f"[red]User '{username}' already exists.[/]")
+        raise typer.Exit(code=1)
+    if password is None:
+        password = typer.prompt(
+            "Password",
+            hide_input=True,
+            confirmation_prompt=True,
+        )
+    try:
+        password_hash = hash_password(password)
+    except ValueError as exc:
+        print(f"[red]{exc}[/]")
+        raise typer.Exit(code=1)
+    if not insert_user(username, password_hash):
+        print(f"[red]User '{username}' already exists.[/]")
+        raise typer.Exit(code=1)
+    print(f"[green]User '{username}' added.[/]")
+
+
+@users_app.command("update")
+def update_user(
+    username: str = typer.Option(..., "--username", help="Username to update."),
+    password: str = typer.Option(
+        None,
+        "--password",
+        help="New password (prompted if omitted).",
+    ),
+):
+    """Update an existing user's password."""
+    if not fetch_user(username):
+        print(f"[red]User '{username}' does not exist.[/]")
+        raise typer.Exit(code=1)
+    if password is None:
+        password = typer.prompt(
+            "Password",
+            hide_input=True,
+            confirmation_prompt=True,
+        )
+    try:
+        password_hash = hash_password(password)
+    except ValueError as exc:
+        print(f"[red]{exc}[/]")
+        raise typer.Exit(code=1)
+    if not update_user_password(username, password_hash):
+        print(f"[red]User '{username}' does not exist.[/]")
+        raise typer.Exit(code=1)
+    print(f"[green]User '{username}' updated.[/]")
+
+
+@users_app.command("remove")
+def remove_user(
+    username: str = typer.Option(..., "--username", help="Username to remove."),
+):
+    """Remove an existing user."""
+    if not delete_user(username):
+        print(f"[red]User '{username}' does not exist.[/]")
+        raise typer.Exit(code=1)
+    print(f"[green]User '{username}' removed.[/]")
 
 
 @app.command()
@@ -126,6 +202,12 @@ def serve(
     host: str = typer.Option("127.0.0.1", help="The host to bind."),
     port: int = typer.Option(8000, help="The port number to use."),
     reload: bool = typer.Option(False, help="Enable auto-reload."),
+    no_auth: bool = typer.Option(
+        False,
+        "--no-auth",
+        hidden=True,
+        help="Disable authentication for local testing.",
+    ),
     ):
     """
     Serves the skedulord API.
@@ -145,6 +227,11 @@ def serve(
         )
     finally:
         sock.close()
+
+    if no_auth:
+        os.environ["SKEDULORD_NO_AUTH"] = "1"
+    else:
+        os.environ.pop("SKEDULORD_NO_AUTH", None)
 
     uvicorn.run("skedulord.api:app", host=host, port=port, reload=reload)
 

--- a/skedulord/api.py
+++ b/skedulord/api.py
@@ -1,11 +1,30 @@
+import base64
+import os
 from pathlib import Path
 from typing import Optional
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
-from skedulord.db import fetch_run, fetch_runs
+from skedulord.auth import verify_password
+from skedulord.db import fetch_run, fetch_runs, fetch_user
+
+
+def _basic_credentials(auth_header: str | None) -> tuple[str, str] | None:
+    if not auth_header:
+        return None
+    if not auth_header.lower().startswith("basic "):
+        return None
+    encoded = auth_header.split(" ", 1)[1].strip()
+    try:
+        decoded = base64.b64decode(encoded).decode("utf-8")
+    except (ValueError, UnicodeDecodeError):
+        return None
+    username, sep, password = decoded.partition(":")
+    if not sep:
+        return None
+    return username, password
 
 
 def create_app() -> FastAPI:
@@ -17,6 +36,27 @@ def create_app() -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    @app.middleware("http")
+    async def auth_middleware(request, call_next):
+        if os.getenv("SKEDULORD_NO_AUTH") == "1":
+            return await call_next(request)
+        path = request.url.path
+        if path in ("/api/health",):
+            return await call_next(request)
+        requires_auth = path.startswith("/api") or path.startswith("/docs") or path == "/openapi.json"
+        if not requires_auth:
+            return await call_next(request)
+        credentials = _basic_credentials(request.headers.get("authorization"))
+        if not credentials:
+            headers = {"WWW-Authenticate": "Basic"} if path.startswith("/docs") or path == "/openapi.json" else None
+            return Response(status_code=401, headers=headers)
+        username, password = credentials
+        row = fetch_user(username)
+        if not row or not verify_password(password, row["password_hash"]):
+            headers = {"WWW-Authenticate": "Basic"} if path.startswith("/docs") or path == "/openapi.json" else None
+            return Response(status_code=401, headers=headers)
+        return await call_next(request)
 
     @app.get("/api/health")
     def health() -> dict:

--- a/skedulord/auth.py
+++ b/skedulord/auth.py
@@ -1,0 +1,39 @@
+import base64
+import hashlib
+import secrets
+
+
+DEFAULT_PBKDF2_ITERATIONS = 390_000
+
+
+def hash_password(password: str, iterations: int = DEFAULT_PBKDF2_ITERATIONS) -> str:
+    if not password:
+        raise ValueError("Password cannot be empty.")
+    salt = secrets.token_bytes(16)
+    digest = hashlib.pbkdf2_hmac(
+        "sha256",
+        password.encode("utf-8"),
+        salt,
+        iterations,
+    )
+    salt_b64 = base64.b64encode(salt).decode("ascii")
+    digest_b64 = base64.b64encode(digest).decode("ascii")
+    return f"pbkdf2_sha256${iterations}${salt_b64}${digest_b64}"
+
+
+def verify_password(password: str, stored: str) -> bool:
+    try:
+        scheme, iterations, salt_b64, digest_b64 = stored.split("$", 3)
+    except ValueError:
+        return False
+    if scheme != "pbkdf2_sha256":
+        return False
+    salt = base64.b64decode(salt_b64.encode("ascii"))
+    expected = base64.b64decode(digest_b64.encode("ascii"))
+    computed = hashlib.pbkdf2_hmac(
+        "sha256",
+        password.encode("utf-8"),
+        salt,
+        int(iterations),
+    )
+    return secrets.compare_digest(computed, expected)

--- a/skedulord/db.py
+++ b/skedulord/db.py
@@ -1,4 +1,5 @@
 import sqlite3
+from contextlib import contextmanager
 from typing import Iterable, Optional
 
 from skedulord.common import db_path
@@ -18,6 +19,11 @@ CREATE TABLE IF NOT EXISTS runs (
 CREATE INDEX IF NOT EXISTS idx_runs_name ON runs(name);
 CREATE INDEX IF NOT EXISTS idx_runs_status ON runs(status);
 CREATE INDEX IF NOT EXISTS idx_runs_start ON runs(start);
+CREATE TABLE IF NOT EXISTS users (
+    username TEXT PRIMARY KEY,
+    password_hash TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
 """
 
 
@@ -27,13 +33,19 @@ def _connect() -> sqlite3.Connection:
     return conn
 
 
-def init_db() -> None:
+@contextmanager
+def _connection() -> Iterable[sqlite3.Connection]:
     conn = _connect()
     try:
-        conn.executescript(SCHEMA)
-        conn.commit()
+        yield conn
     finally:
         conn.close()
+
+
+def init_db() -> None:
+    with _connection() as conn:
+        conn.executescript(SCHEMA)
+        conn.commit()
 
 
 def insert_run(
@@ -46,8 +58,7 @@ def insert_run(
     logpath: str,
 ) -> None:
     init_db()
-    conn = _connect()
-    try:
+    with _connection() as conn:
         conn.execute(
             """
             INSERT OR REPLACE INTO runs (id, name, command, status, start, end, logpath)
@@ -56,8 +67,6 @@ def insert_run(
             (run_id, name, command, status, start, end, logpath),
         )
         conn.commit()
-    finally:
-        conn.close()
 
 
 def fetch_runs(
@@ -67,8 +76,7 @@ def fetch_runs(
     date: Optional[str] = None,
 ) -> Iterable[sqlite3.Row]:
     init_db()
-    conn = _connect()
-    try:
+    with _connection() as conn:
         clauses = []
         params = []
         if name:
@@ -90,14 +98,11 @@ def fetch_runs(
         {limit_clause}
         """
         return conn.execute(query, params).fetchall()
-    finally:
-        conn.close()
 
 
 def fetch_run(run_id: str) -> Optional[sqlite3.Row]:
     init_db()
-    conn = _connect()
-    try:
+    with _connection() as conn:
         return conn.execute(
             """
             SELECT id, name, command, status, start, end, logpath
@@ -106,5 +111,59 @@ def fetch_run(run_id: str) -> Optional[sqlite3.Row]:
             """,
             (run_id,),
         ).fetchone()
-    finally:
-        conn.close()
+
+
+def fetch_user(username: str) -> Optional[sqlite3.Row]:
+    init_db()
+    with _connection() as conn:
+        return conn.execute(
+            """
+            SELECT username, password_hash, created_at
+            FROM users
+            WHERE username = ?
+            """,
+            (username,),
+        ).fetchone()
+
+
+def insert_user(username: str, password_hash: str) -> bool:
+    init_db()
+    with _connection() as conn:
+        cursor = conn.execute(
+            """
+            INSERT OR IGNORE INTO users (username, password_hash)
+            VALUES (?, ?)
+            """,
+            (username, password_hash),
+        )
+        conn.commit()
+        return cursor.rowcount > 0
+
+
+def update_user_password(username: str, password_hash: str) -> bool:
+    init_db()
+    with _connection() as conn:
+        cursor = conn.execute(
+            """
+            UPDATE users
+            SET password_hash = ?
+            WHERE username = ?
+            """,
+            (password_hash, username),
+        )
+        conn.commit()
+        return cursor.rowcount > 0
+
+
+def delete_user(username: str) -> bool:
+    init_db()
+    with _connection() as conn:
+        cursor = conn.execute(
+            """
+            DELETE FROM users
+            WHERE username = ?
+            """,
+            (username,),
+        )
+        conn.commit()
+        return cursor.rowcount > 0

--- a/skedulord/demo_seed.py
+++ b/skedulord/demo_seed.py
@@ -3,8 +3,9 @@ import random
 import uuid
 from pathlib import Path
 
+from skedulord.auth import hash_password
 from skedulord.common import job_name_path
-from skedulord.db import insert_run
+from skedulord.db import fetch_user, insert_run, insert_user, update_user_password
 
 
 def _isoformat(value: dt.datetime) -> str:
@@ -19,6 +20,12 @@ def _write_log(path: Path, lines: list[str]) -> None:
 def main() -> None:
     random.seed(42)
     now = dt.datetime.now(dt.timezone.utc)
+
+    admin_hash = hash_password("admin")
+    if fetch_user("admin"):
+        update_user_password("admin", admin_hash)
+    else:
+        insert_user("admin", admin_hash)
 
     job_names = [
         "billing-rollup",

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -970,7 +970,7 @@ export default function App() {
     setQuery("");
   }
 
-  function handleCommandKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+  function handleCommandKeyDown(event: KeyboardEvent<HTMLElement>) {
     if (event.key === "Escape") {
       event.preventDefault();
       if (commandView !== "root") {
@@ -1714,6 +1714,7 @@ export default function App() {
             aria-modal="true"
             aria-label="Command palette"
             onClick={(event) => event.stopPropagation()}
+            onKeyDown={handleCommandKeyDown}
           >
             <div className="flex items-center gap-2 rounded-2xl border border-ink/10 bg-white/70 px-3 py-2 text-sm text-ink dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100">
               <Search className="h-4 w-4 text-ink/40 dark:text-slate-400" />
@@ -1722,7 +1723,6 @@ export default function App() {
                 type="search"
                 value={query}
                 onChange={(event) => setQuery(event.target.value)}
-                onKeyDown={handleCommandKeyDown}
                 placeholder={
                   normalizedQuery
                     ? "Search jobs or actions…"
@@ -1740,45 +1740,51 @@ export default function App() {
               {commandItems.length === 0 ? (
                 <p className="px-3 py-4 text-sm text-ink/50 dark:text-slate-400">No matching commands.</p>
               ) : (
-                commandItems.map((item, index) => (
-                  <button
-                    key={item.id}
-                    type="button"
-                    onClick={() => handleSuggestionSelect(item)}
-                    ref={(node) => {
-                      commandItemRefs.current[index] = node;
-                    }}
-                    className={`flex w-full items-center justify-between rounded-2xl px-3 py-2 text-left text-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ink dark:focus-visible:outline-slate-100 ${
-                      item.type === "route"
-                        ? "gap-4 border border-ink/10 bg-white/80 px-4 py-3 text-ink shadow-card dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100"
-                        : ""
-                    } ${
-                      index === highlightIndex
-                        ? "bg-ink/5 text-ink dark:bg-white/10 dark:text-slate-100"
-                        : "text-ink/70 hover:bg-ink/5 hover:text-ink dark:text-slate-300 dark:hover:bg-white/10 dark:hover:text-slate-100"
-                    }`}
-                    aria-selected={index === highlightIndex}
-                    role="option"
-                  >
-                    <div>
-                      <span className="block">{item.label}</span>
-                      {item.type === "route" ? (
-                        <span className="mt-1 block text-xs text-ink/50 dark:text-slate-400">
-                          {item.description}
+                commandItems.map((item, index) => {
+                  const isSelected = index === highlightIndex;
+                  const isRoute = item.type === "route";
+                  const selectedClass = isSelected
+                    ? isRoute
+                      ? "bg-ink/10 text-ink border-2 border-ink/40 dark:bg-white/10 dark:text-slate-100 dark:border-white/30"
+                      : "text-ink border border-ink/35 font-semibold dark:border-white/20 dark:text-slate-100"
+                    : "text-ink/70 hover:bg-ink/5 hover:text-ink dark:text-slate-300 dark:hover:bg-white/10 dark:hover:text-slate-100";
+
+                  return (
+                    <button
+                      key={item.id}
+                      type="button"
+                      onClick={() => handleSuggestionSelect(item)}
+                      ref={(node) => {
+                        commandItemRefs.current[index] = node;
+                      }}
+                      className={`flex w-full items-center justify-between rounded-2xl px-3 py-2 text-left text-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ink dark:focus-visible:outline-slate-100 ${
+                        isRoute
+                          ? "gap-4 border border-ink/10 bg-white/80 px-4 py-3 text-ink shadow-card dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100"
+                          : ""
+                      } ${selectedClass}`}
+                      aria-selected={isSelected}
+                      role="option"
+                    >
+                      <div>
+                        <span className="block">{item.label}</span>
+                        {item.type === "route" ? (
+                          <span className="mt-1 block text-xs text-ink/50 dark:text-slate-400">
+                            {item.description}
+                          </span>
+                        ) : null}
+                      </div>
+                      {item.type === "action" ? (
+                        <span className="rounded-full border border-ink/10 px-2 py-0.5 text-xs text-ink/40 dark:border-white/10 dark:text-slate-400">
+                          {item.shortcut ?? ""}
                         </span>
-                      ) : null}
-                    </div>
-                    {item.type === "action" ? (
-                      <span className="rounded-full border border-ink/10 px-2 py-0.5 text-xs text-ink/40 dark:border-white/10 dark:text-slate-400">
-                        {item.shortcut ?? ""}
-                      </span>
-                    ) : item.type === "job" ? (
-                      <span className="text-xs text-ink/40 dark:text-slate-400">Job</span>
-                    ) : (
-                      <span className="text-xs text-ink/40 dark:text-slate-400">Enter</span>
-                    )}
-                  </button>
-                ))
+                      ) : item.type === "job" ? (
+                        <span className="text-xs text-ink/40 dark:text-slate-400">Job</span>
+                      ) : (
+                        <span className="text-xs text-ink/40 dark:text-slate-400">Enter</span>
+                      )}
+                    </button>
+                  );
+                })
               )}
             </div>
           </div>

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
+import { useEffect, useMemo, useRef, useState, type FormEvent, type KeyboardEvent } from "react";
 import * as ScrollArea from "@radix-ui/react-scroll-area";
 import {
   AlertCircle,
@@ -7,16 +7,25 @@ import {
   Copy,
   CornerUpLeft,
   Filter,
+  LogOut,
   Search,
   Moon,
   RefreshCw,
   Sun
 } from "lucide-react";
 
-import { fetchLog, fetchRuns, type RunEntry } from "./api";
+import {
+  ApiError,
+  clearAuthHeader,
+  fetchLog,
+  fetchRuns,
+  setAuthHeader,
+  type RunEntry
+} from "./api";
 
 const MAX_RECENT_RUNS = 20;
 const RUNS_PER_PAGE = 25;
+const AUTH_STORAGE_KEY = "skedulord_basic_auth";
 
 function statusColor(status: string) {
   if (status === "success") return "bg-emerald-500";
@@ -128,6 +137,95 @@ function RunBars({
   );
 }
 
+function LoginScreen({
+  theme,
+  onToggleTheme,
+  onSubmit,
+  error,
+  busy,
+  username,
+  password,
+  onUsernameChange,
+  onPasswordChange
+}: {
+  theme: "light" | "dark";
+  onToggleTheme: () => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  error: string | null;
+  busy: boolean;
+  username: string;
+  password: string;
+  onUsernameChange: (value: string) => void;
+  onPasswordChange: (value: string) => void;
+}) {
+  const isDark = theme === "dark";
+  return (
+    <div className="app-shell">
+      <div className="mx-auto flex min-h-screen max-w-xl flex-col gap-8 px-6 py-12">
+        <header className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <p className="text-xs uppercase tracking-[0.4em] text-plum dark:text-orange-300">Skedulord</p>
+            <h1 className="mt-2 text-3xl font-semibold text-ink dark:text-slate-100">Sign in</h1>
+          </div>
+          <button
+            onClick={onToggleTheme}
+            className="inline-flex h-9 items-center gap-2 rounded-full border border-ink/10 bg-white/80 px-4 text-xs font-semibold text-ink shadow-sm transition hover:-translate-y-0.5 hover:shadow-card focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ink dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100"
+            type="button"
+            aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+          >
+            {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+            {isDark ? "Light" : "Dark"}
+          </button>
+        </header>
+
+        <section className="rounded-3xl border border-ink/10 bg-white/80 p-8 shadow-card dark:border-white/10 dark:bg-slate-900/70">
+          <form onSubmit={onSubmit} className="flex flex-col gap-4">
+            <label className="flex flex-col gap-2 text-sm font-semibold text-ink dark:text-slate-100">
+              Username
+              <input
+                value={username}
+                onChange={(event) => onUsernameChange(event.target.value)}
+                type="text"
+                name="username"
+                autoComplete="username"
+                autoFocus
+                className="h-11 rounded-2xl border border-ink/10 bg-white/90 px-4 text-sm font-normal text-ink shadow-sm focus:border-ink/40 focus:outline-none focus:ring-2 focus:ring-ink/10 dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100 dark:focus:border-white/40 dark:focus:ring-white/10"
+                required
+              />
+            </label>
+            <label className="flex flex-col gap-2 text-sm font-semibold text-ink dark:text-slate-100">
+              Password
+              <input
+                value={password}
+                onChange={(event) => onPasswordChange(event.target.value)}
+                type="password"
+                name="password"
+                autoComplete="current-password"
+                className="h-11 rounded-2xl border border-ink/10 bg-white/90 px-4 text-sm font-normal text-ink shadow-sm focus:border-ink/40 focus:outline-none focus:ring-2 focus:ring-ink/10 dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100 dark:focus:border-white/40 dark:focus:ring-white/10"
+                required
+              />
+            </label>
+            {error ? (
+              <div className="flex items-center gap-2 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-xs text-rose-700 dark:border-rose-500/40 dark:bg-rose-500/10 dark:text-rose-200">
+                <AlertCircle className="h-4 w-4" />
+                {error}
+              </div>
+            ) : null}
+            <button
+              type="submit"
+              disabled={busy}
+              className="mt-2 inline-flex h-11 items-center justify-center gap-2 rounded-2xl bg-ink px-4 text-sm font-semibold text-white shadow-soft transition hover:-translate-y-0.5 hover:shadow-card disabled:cursor-not-allowed disabled:opacity-60 dark:bg-white dark:text-ink"
+            >
+              {busy ? "Signing in..." : "Login"}
+              <CornerUpLeft className="h-4 w-4" />
+            </button>
+          </form>
+        </section>
+      </div>
+    </div>
+  );
+}
+
 type SuggestionItem =
   | {
       id: string;
@@ -171,6 +269,11 @@ export default function App() {
     if (stored === "light" || stored === "dark") return stored;
     return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
   });
+  const [authRequired, setAuthRequired] = useState(false);
+  const [authError, setAuthError] = useState<string | null>(null);
+  const [authBusy, setAuthBusy] = useState(false);
+  const [loginUsername, setLoginUsername] = useState("");
+  const [loginPassword, setLoginPassword] = useState("");
   const [runs, setRuns] = useState<RunEntry[]>([]);
   const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(false);
@@ -202,6 +305,22 @@ export default function App() {
   const hasHydratedRef = useRef(false);
   const copyResetRef = useRef<number | null>(null);
 
+  function clearStoredAuth() {
+    clearAuthHeader();
+    if (typeof window !== "undefined") {
+      window.sessionStorage.removeItem(AUTH_STORAGE_KEY);
+    }
+    setLoginPassword("");
+  }
+
+  function saveStoredAuth(username: string, password: string) {
+    if (typeof window === "undefined") return;
+    window.sessionStorage.setItem(
+      AUTH_STORAGE_KEY,
+      JSON.stringify({ username, password })
+    );
+  }
+
   async function handleCopyPath(path?: string | null) {
     if (!path) return;
     try {
@@ -221,12 +340,74 @@ export default function App() {
     try {
       const data = await fetchRuns({ limit: 500 });
       setRuns(data);
+      setAuthRequired(false);
+      setAuthError(null);
     } catch (err) {
-      setError((err as Error).message);
+      if (err instanceof ApiError && err.status === 401) {
+        clearStoredAuth();
+        setAuthRequired(true);
+        setAuthError(null);
+      } else {
+        setError((err as Error).message);
+      }
     } finally {
       setLoading(false);
     }
   }
+
+  async function handleLogin(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!loginUsername || !loginPassword) {
+      setAuthError("Username and password are required.");
+      return;
+    }
+    setAuthBusy(true);
+    setAuthError(null);
+    setAuthHeader(loginUsername, loginPassword);
+    try {
+      await fetchRuns({ limit: 1 });
+      saveStoredAuth(loginUsername, loginPassword);
+      setAuthRequired(false);
+      await loadRuns();
+    } catch (err) {
+      clearStoredAuth();
+      if (err instanceof ApiError && err.status === 401) {
+        setAuthError("Invalid username or password.");
+      } else {
+        setAuthError("Unable to reach the server.");
+      }
+    } finally {
+      setAuthBusy(false);
+    }
+  }
+
+  function handleLogout() {
+    clearStoredAuth();
+    setAuthRequired(true);
+    setRuns([]);
+    setSelectedJob(null);
+    setSelectedRunId(null);
+    setFocusedRunId(null);
+    setFocusedRun(null);
+    setLogData(null);
+    setLogError(null);
+  }
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = window.sessionStorage.getItem(AUTH_STORAGE_KEY);
+    if (!stored) return;
+    try {
+      const parsed = JSON.parse(stored) as { username?: string; password?: string };
+      if (parsed.username && parsed.password) {
+        setAuthHeader(parsed.username, parsed.password);
+        setLoginUsername(parsed.username);
+        setLoginPassword(parsed.password);
+      }
+    } catch {
+      window.sessionStorage.removeItem(AUTH_STORAGE_KEY);
+    }
+  }, []);
 
   useEffect(() => {
     loadRuns();
@@ -383,6 +564,12 @@ export default function App() {
       })
       .catch((err) => {
         if (!active) return;
+        if (err instanceof ApiError && err.status === 401) {
+          clearStoredAuth();
+          setAuthRequired(true);
+          setAuthError(null);
+          return;
+        }
         setLogError((err as Error).message);
       })
       .finally(() => {
@@ -959,6 +1146,22 @@ export default function App() {
       ]
     }
   ];
+
+  if (authRequired) {
+    return (
+      <LoginScreen
+        theme={theme}
+        onToggleTheme={() => setTheme(isDark ? "light" : "dark")}
+        onSubmit={handleLogin}
+        error={authError}
+        busy={authBusy}
+        username={loginUsername}
+        password={loginPassword}
+        onUsernameChange={setLoginUsername}
+        onPasswordChange={setLoginPassword}
+      />
+    );
+  }
   return (
     <div className="app-shell">
       <div className="mx-auto flex min-h-screen max-w-6xl flex-col gap-6 px-6 py-10">
@@ -1049,6 +1252,13 @@ export default function App() {
               <RefreshCw className="h-4 w-4" />
               Refresh
               <span className={headerKeycapClass}>R</span>
+            </button>
+            <button
+              onClick={handleLogout}
+              className={headerButtonClass}
+            >
+              <LogOut className="h-4 w-4" />
+              Sign out
             </button>
           </div>
         </header>

--- a/webapp/src/api.ts
+++ b/webapp/src/api.ts
@@ -10,7 +10,29 @@ export interface RunEntry {
   logpath: string;
 }
 
+export class ApiError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
 const apiBase = (import.meta.env.VITE_API_URL ?? "").replace(/\/$/, "");
+let authHeader: string | null = null;
+
+function authHeaders() {
+  return authHeader ? { Authorization: authHeader } : {};
+}
+
+export function setAuthHeader(username: string, password: string) {
+  authHeader = `Basic ${btoa(`${username}:${password}`)}`;
+}
+
+export function clearAuthHeader() {
+  authHeader = null;
+}
 
 export async function fetchRuns(params: {
   limit?: number;
@@ -23,17 +45,21 @@ export async function fetchRuns(params: {
   if (params.name) query.set("name", params.name);
   if (params.status) query.set("status", params.status);
   if (params.date) query.set("date", params.date);
-  const response = await fetch(`${apiBase}/api/runs?${query.toString()}`);
+  const response = await fetch(`${apiBase}/api/runs?${query.toString()}`, {
+    headers: authHeaders()
+  });
   if (!response.ok) {
-    throw new Error("Failed to load runs");
+    throw new ApiError(response.status, "Failed to load runs");
   }
   return response.json();
 }
 
 export async function fetchLog(runId: string): Promise<{ logpath: string; content: string }> {
-  const response = await fetch(`${apiBase}/api/logs/${runId}`);
+  const response = await fetch(`${apiBase}/api/logs/${runId}`, {
+    headers: authHeaders()
+  });
   if (!response.ok) {
-    throw new Error("Failed to load log");
+    throw new ApiError(response.status, "Failed to load log");
   }
   return response.json();
 }


### PR DESCRIPTION
Adds user management commands and hashed credentials for the API/dashboard.\nImplements basic auth enforcement with a hidden no-auth flag for local testing.\nAdds a minimal login UI that stores session credentials and avoids browser auth prompts.\nSeeds an admin/admin user for demo runs.