### PR TITLE
Harden API auth, log access, and CORS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: lint install develop test check clean reset reset-big pypi \
-	demo-reset demo-seed demo-run demo-web demo-clean demo-install demo-ui-build demo-check
+	demo-reset demo-seed demo-run demo-run-dev demo-web demo-clean demo-install demo-ui-build demo-check
 
 lint:
 	ruff check skedulord tests
@@ -60,6 +60,10 @@ demo-seed:
 
 demo-run: demo-reset demo-seed demo-ui-build
 	uv run python -m skedulord serve --reload
+
+demo-run-dev: demo-reset demo-seed
+	SKEDULORD_CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173 \
+		uv run python -m skedulord serve --reload
 
 
 demo-web:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
 dev = [
   "pytest",
   "pytest-cov",
+  "httpx",
   "mkdocs-material>=6.2.8",
   "ruff>=0.5.0",
 ]

--- a/skedulord/__main__.py
+++ b/skedulord/__main__.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -16,6 +15,7 @@ from skedulord.common import SKEDULORD_PATH
 from skedulord.cron import Cron, clean_cron, parse_job_from_settings
 from skedulord.db import delete_user, fetch_runs, fetch_user, insert_user, update_user_password
 from skedulord.templating import render_tokens
+from skedulord.api import create_app
 
 app = typer.Typer(
     name="SKEDULORD",
@@ -227,12 +227,12 @@ def serve(
     finally:
         sock.close()
 
-    if no_auth:
-        os.environ["SKEDULORD_NO_AUTH"] = "1"
-    else:
-        os.environ.pop("SKEDULORD_NO_AUTH", None)
+    if no_auth and reload:
+        typer.echo("Disabling reload because --no-auth requires an in-memory app instance.")
+        reload = False
 
-    uvicorn.run("skedulord.api:app", host=host, port=port, reload=reload)
+    app = create_app(no_auth=no_auth)
+    uvicorn.run(app, host=host, port=port, reload=reload)
 
 
 if __name__ == "__main__":

--- a/skedulord/api.py
+++ b/skedulord/api.py
@@ -94,7 +94,7 @@ def create_app(no_auth: bool = False, cors_origins: list[str] | None = None) -> 
         return dict(row)
 
     @app.get("/api/logs/{run_id}")
-    def get_log(run_id: str) -> dict:
+    def get_log(run_id: str, max_lines: int = 2000) -> dict:
         row = fetch_run(run_id)
         if not row:
             raise HTTPException(status_code=404, detail="Run not found")
@@ -107,7 +107,18 @@ def create_app(no_auth: bool = False, cors_origins: list[str] | None = None) -> 
             raise HTTPException(status_code=403, detail="Log file is outside the skedulord data directory")
         if not logpath.exists():
             raise HTTPException(status_code=404, detail="Log file not found")
-        return {"logpath": str(resolved_logpath), "content": logpath.read_text()}
+        if max_lines <= 0:
+            raise HTTPException(status_code=400, detail="max_lines must be positive")
+        lines = logpath.read_text().splitlines()
+        truncated = len(lines) > max_lines
+        if truncated:
+            lines = lines[-max_lines:]
+        return {
+            "logpath": str(resolved_logpath),
+            "content": "\n".join(lines),
+            "truncated": truncated,
+            "max_lines": max_lines,
+        }
 
     repo_root = Path(__file__).resolve().parents[1]
     dist_path = repo_root / "webapp" / "dist"

--- a/skedulord/api.py
+++ b/skedulord/api.py
@@ -8,6 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
 from skedulord.auth import verify_password
+from skedulord.common import skedulord_path
 from skedulord.db import fetch_run, fetch_runs, fetch_user
 
 
@@ -27,19 +28,23 @@ def _basic_credentials(auth_header: str | None) -> tuple[str, str] | None:
     return username, password
 
 
-def create_app() -> FastAPI:
+def create_app(no_auth: bool = False, cors_origins: list[str] | None = None) -> FastAPI:
     app = FastAPI(title="Skedulord API", version="0.1.0")
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=["*"],
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
+    if cors_origins is None:
+        env_origins = os.getenv("SKEDULORD_CORS_ORIGINS", "")
+        cors_origins = [origin.strip() for origin in env_origins.split(",") if origin.strip()]
+    if cors_origins:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=cors_origins,
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
 
     @app.middleware("http")
     async def auth_middleware(request, call_next):
-        if os.getenv("SKEDULORD_NO_AUTH") == "1":
+        if no_auth:
             return await call_next(request)
         path = request.url.path
         if path in ("/api/health",):
@@ -94,9 +99,15 @@ def create_app() -> FastAPI:
         if not row:
             raise HTTPException(status_code=404, detail="Run not found")
         logpath = Path(row["logpath"])
+        base_path = skedulord_path().resolve()
+        resolved_logpath = logpath.resolve()
+        try:
+            resolved_logpath.relative_to(base_path)
+        except ValueError:
+            raise HTTPException(status_code=403, detail="Log file is outside the skedulord data directory")
         if not logpath.exists():
             raise HTTPException(status_code=404, detail="Log file not found")
-        return {"logpath": str(logpath), "content": logpath.read_text()}
+        return {"logpath": str(resolved_logpath), "content": logpath.read_text()}
 
     repo_root = Path(__file__).resolve().parents[1]
     dist_path = repo_root / "webapp" / "dist"

--- a/tests/test_api_security.py
+++ b/tests/test_api_security.py
@@ -4,6 +4,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from skedulord.api import create_app
+from skedulord.common import skedulord_path
 from skedulord.db import insert_run
 
 
@@ -45,3 +46,27 @@ def test_cors_enabled_via_env(clean_slate, monkeypatch):
     client = TestClient(create_app(no_auth=True))
     response = client.get("/api/health", headers={"Origin": "http://localhost:5173"})
     assert response.headers.get("access-control-allow-origin") == "http://localhost:5173"
+
+
+def test_logs_endpoint_limits_lines(clean_slate, tmp_path):
+    logpath = skedulord_path() / "long" / "long.log"
+    logpath.parent.mkdir(parents=True, exist_ok=True)
+    logpath.write_text("\n".join([f"line-{idx}" for idx in range(5)]))
+
+    insert_run(
+        run_id="run-long",
+        name="long",
+        command="echo long",
+        status="success",
+        start="2024-01-01 00:00:00",
+        end="2024-01-01 00:00:01",
+        logpath=str(logpath),
+    )
+
+    client = TestClient(create_app(no_auth=True))
+    response = client.get("/api/logs/run-long", params={"max_lines": 2})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["content"] == "line-3\nline-4"
+    assert payload["truncated"] is True
+    assert payload["max_lines"] == 2

--- a/tests/test_api_security.py
+++ b/tests/test_api_security.py
@@ -1,0 +1,47 @@
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from skedulord.api import create_app
+from skedulord.db import insert_run
+
+
+@pytest.fixture()
+def clean_slate():
+    os.system("python -m skedulord wipe disk --really --yes")
+    yield 1
+    os.system("python -m skedulord wipe disk --really --yes")
+
+
+def test_logs_endpoint_rejects_paths_outside_data_dir(clean_slate, tmp_path):
+    external_log = tmp_path / "external.log"
+    external_log.write_text("do not read")
+
+    insert_run(
+        run_id="run-outside",
+        name="outside",
+        command="echo outside",
+        status="success",
+        start="2024-01-01 00:00:00",
+        end="2024-01-01 00:00:01",
+        logpath=str(external_log),
+    )
+
+    client = TestClient(create_app(no_auth=True))
+    response = client.get("/api/logs/run-outside")
+    assert response.status_code == 403
+
+
+def test_cors_disabled_by_default(clean_slate, monkeypatch):
+    monkeypatch.delenv("SKEDULORD_CORS_ORIGINS", raising=False)
+    client = TestClient(create_app(no_auth=True))
+    response = client.get("/api/health", headers={"Origin": "http://localhost:5173"})
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_cors_enabled_via_env(clean_slate, monkeypatch):
+    monkeypatch.setenv("SKEDULORD_CORS_ORIGINS", "http://localhost:5173")
+    client = TestClient(create_app(no_auth=True))
+    response = client.get("/api/health", headers={"Origin": "http://localhost:5173"})
+    assert response.headers.get("access-control-allow-origin") == "http://localhost:5173"


### PR DESCRIPTION
Remove env-based auth bypass, keep CLI flag via in-memory app.\nGuard log reads to stay inside skedulord data directory and add tests.\nMake CORS opt-in via SKEDULORD_CORS_ORIGINS with a dev target and tests.\nAdd httpx to dev dependencies for TestClient.