### PR TITLE
Add init command scaffolding

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -13,6 +13,17 @@ Options:
   --help           Show this message and exit.
 ```
 
+## `init`
+
+Initialize a starter `.env`, `schedule.yml`, example script, and sqlite database.
+
+```text
+Options:
+  -p, --path PATH  Directory to write .env and schedule.yml.  [default: .]
+  --force          Overwrite existing files.  [default: False]
+  --help           Show this message and exit.
+```
+
 ## `schedule`  
 
 Set (or reset) cron jobs based on config.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ Options:
 
 Commands:
   history   Shows a table with job status.
+  init      Initialize a starter .env, schedule.yml, and sqlite database.
   run       Run a single command, which is logged by skedulord.
   schedule  Set (or reset) cron jobs based on config.
   serve     Serves the Skedulord API (and webapp if built).

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,7 @@ Commands:
   schedule  Set (or reset) cron jobs based on config.
   run       Run a single command, which is logged by skedulord.
   history   Shows a table with job status.
+  init      Initialize a starter .env, schedule.yml, and sqlite database.
   serve     Serves the Skedulord API (and webapp if built).
   wipe      Wipe the disk or schedule state.
   version   Show the version.

--- a/skedulord/__main__.py
+++ b/skedulord/__main__.py
@@ -1,3 +1,4 @@
+import getpass
 import os
 import shutil
 import subprocess
@@ -14,7 +15,14 @@ from skedulord.auth import hash_password
 from skedulord.job import JobRunner
 from skedulord.common import SKEDULORD_PATH
 from skedulord.cron import Cron, clean_cron, parse_job_from_settings
-from skedulord.db import delete_user, fetch_runs, fetch_user, insert_user, update_user_password
+from skedulord.db import (
+    delete_user,
+    fetch_runs,
+    fetch_user,
+    init_db,
+    insert_user,
+    update_user_password,
+)
 from skedulord.templating import render_tokens
 
 app = typer.Typer(
@@ -110,6 +118,90 @@ def main(ctx: typer.Context):
 def version():
     """Show the version."""
     print(lord_version)
+
+
+@app.command()
+def init(
+    path: Path = typer.Option(
+        Path("."),
+        "--path",
+        "-p",
+        help="Directory to write .env and schedule.yml.",
+    ),
+    force: bool = typer.Option(False, help="Overwrite existing files."),
+):
+    """Initialize a starter .env, schedule.yml, and sqlite database."""
+    path = path.expanduser().resolve()
+    path.mkdir(parents=True, exist_ok=True)
+
+    user = getpass.getuser()
+    env_path = path / ".env"
+    schedule_path = path / "schedule.yml"
+    script_path = path / "example_job.py"
+    targets = [env_path, schedule_path, script_path]
+
+    if not force:
+        existing = [target for target in targets if target.exists()]
+        if existing:
+            print("[yellow]Skipped init because files already exist:[/]")
+            for target in existing:
+                print(f"[yellow]- {target}[/]")
+            print("[yellow]Re-run with --force to overwrite.[/]")
+            raise typer.Exit(code=1)
+
+    env_contents = "\n".join(
+        [
+            "# Skedulord environment (edit as needed).",
+            "# WARNING: never put secrets in frontend VITE_* variables.",
+            "SKEDULORD_NO_AUTH=0",
+            "SKEDULORD_EXAMPLE_MESSAGE=hello from skedulord",
+            "",
+        ]
+    )
+
+    schedule_contents = "\n".join(
+        [
+            "user: " + user,
+            "schedule:",
+            "  - name: example",
+            f"    command: {script_path}",
+            "    cron: \"*/5 * * * *\"",
+            "",
+        ]
+    )
+
+    script_contents = "\n".join(
+        [
+            "#!/usr/bin/env -S uv run python",
+            "# /// script",
+            "# dependencies = [\"python-dotenv\"]",
+            "# ///",
+            "from __future__ import annotations",
+            "",
+            "from pathlib import Path",
+            "import os",
+            "",
+            "from dotenv import load_dotenv",
+            "",
+            "env_path = Path(__file__).with_name(\".env\")",
+            "load_dotenv(env_path)",
+            "",
+            "message = os.getenv(\"SKEDULORD_EXAMPLE_MESSAGE\", \"hello from skedulord\")",
+            "print(message)",
+            "",
+        ]
+    )
+
+    for target, contents, label in [
+        (env_path, env_contents, ".env"),
+        (schedule_path, schedule_contents, "schedule.yml"),
+        (script_path, script_contents, "example_job.py"),
+    ]:
+        target.write_text(contents, encoding="utf8")
+        print(f"[green]Wrote {label} to {target}.[/]")
+
+    init_db()
+    print(f"[green]Initialized sqlite database at {Path(SKEDULORD_PATH) / 'skedulord.db'}.[/]")
 
 
 @app.command()

--- a/tests/test_init_command.py
+++ b/tests/test_init_command.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from skedulord.__main__ import app
+
+
+def test_init_creates_files_and_db(tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(app, ["init", "--path", str(tmp_path)])
+    assert result.exit_code == 0
+    assert (tmp_path / ".env").exists()
+    assert (tmp_path / "schedule.yml").exists()
+    assert (tmp_path / "example_job.py").exists()
+    assert (Path.home() / ".skedulord" / "skedulord.db").exists()
+
+
+def test_init_refuses_when_files_exist(tmp_path):
+    (tmp_path / ".env").write_text("SKEDULORD_NO_AUTH=0\n", encoding="utf8")
+    runner = CliRunner()
+    result = runner.invoke(app, ["init", "--path", str(tmp_path)])
+    assert result.exit_code != 0
+    assert "Skipped init because files already exist" in result.output
+
+
+def test_init_force_overwrites(tmp_path):
+    env_path = tmp_path / ".env"
+    env_path.write_text("OLD=1\n", encoding="utf8")
+    runner = CliRunner()
+    result = runner.invoke(app, ["init", "--path", str(tmp_path), "--force"])
+    assert result.exit_code == 0
+    assert "OLD=1" not in env_path.read_text(encoding="utf8")


### PR DESCRIPTION
Adds a skedulord init command that scaffolds .env, schedule.yml, and an example script, and initializes the sqlite DB.
Includes tests to ensure init refuses when files exist unless --force is used.