### PR TITLE
Resolve cron schedule paths

### DIFF
--- a/skedulord/cron.py
+++ b/skedulord/cron.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import typer
 from clumper import Clumper
 from crontab import CronTab
@@ -28,8 +30,8 @@ def parse_job_from_settings(settings: dict, name: str) -> dict:
 
 class Cron:
     def __init__(self, settings_path):
-        self.settings_path = settings_path
-        self.settings = Clumper.read_yaml(settings_path).unpack("schedule").collect()
+        self.settings_path = Path(settings_path).resolve()
+        self.settings = Clumper.read_yaml(self.settings_path).unpack("schedule").collect()
 
     def parse_cmd(self, setting: dict) -> str:
         """

--- a/tests/test_cron_parsing.py
+++ b/tests/test_cron_parsing.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from skedulord.cron import parse_job_from_settings, Cron
 
@@ -34,8 +36,10 @@ def test_job_parsing(check):
 def test_cron_obj_parsing():
     """Test that the cron object parses the schedule appropriately"""
     c = Cron("tests/schedule.yml")
+    expected_path = Path("tests/schedule.yml").resolve()
     for s in c.settings:
         parsed_command = c.parse_cmd(s)
         assert parsed_command.rstrip() == parsed_command
         assert "uv run python -m skedulord run" in parsed_command
         assert "--settings-path" in parsed_command
+        assert str(expected_path) in parsed_command


### PR DESCRIPTION
Resolve schedule.yml paths to absolute when writing cron commands. Add a test assertion to ensure the absolute path is embedded.