### PR TITLE
Use static version in pyproject.toml instead of dynamic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skedulord"
-dynamic = ["version"]
+version = "3.0.0"
 description = "A tool that automates scheduling and logging of jobs."
 readme = "readme.md"
 requires-python = ">=3.9"
@@ -32,9 +32,6 @@ dev = [
 
 [project.scripts]
 skedulord = "skedulord.__main__:app"
-
-[tool.setuptools.dynamic]
-version = {attr = "skedulord.__version__"}
 
 [tool.setuptools]
 include-package-data = true

--- a/skedulord/__init__.py
+++ b/skedulord/__init__.py
@@ -1,2 +1,4 @@
-__version__ = "2.0.0"
+from importlib.metadata import version
+
+__version__ = version("skedulord")
 __all__ = ["__version__"]


### PR DESCRIPTION
Replace dynamic version discovery from skedulord.__version__ with a static version field in pyproject.toml. Update __init__.py to read the version from package metadata at runtime, eliminating duplicate version definitions and improving build simplicity.

## Changes

- Changed version to static "3.0.0" in pyproject.toml
- Removed setuptools.dynamic configuration section
- Updated __init__.py to read version from package metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)