### PR TITLE
Add retry attempt tracking to demo data and UI

### DIFF
--- a/skedulord/db.py
+++ b/skedulord/db.py
@@ -14,6 +14,7 @@ CREATE TABLE IF NOT EXISTS runs (
     start TEXT NOT NULL,
     end TEXT NOT NULL,
     logpath TEXT NOT NULL,
+    attempt INTEGER NOT NULL DEFAULT 1,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 CREATE INDEX IF NOT EXISTS idx_runs_name ON runs(name);
@@ -56,15 +57,16 @@ def insert_run(
     start: str,
     end: str,
     logpath: str,
+    attempt: int = 1,
 ) -> None:
     init_db()
     with _connection() as conn:
         conn.execute(
             """
-            INSERT OR REPLACE INTO runs (id, name, command, status, start, end, logpath)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            INSERT OR REPLACE INTO runs (id, name, command, status, start, end, logpath, attempt)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (run_id, name, command, status, start, end, logpath),
+            (run_id, name, command, status, start, end, logpath, attempt),
         )
         conn.commit()
 
@@ -91,7 +93,7 @@ def fetch_runs(
         where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
         limit_clause = f"LIMIT {int(limit)}" if limit else ""
         query = f"""
-        SELECT id, name, command, status, start, end, logpath
+        SELECT id, name, command, status, start, end, logpath, attempt
         FROM runs
         {where}
         ORDER BY start DESC
@@ -105,7 +107,7 @@ def fetch_run(run_id: str) -> Optional[sqlite3.Row]:
     with _connection() as conn:
         return conn.execute(
             """
-            SELECT id, name, command, status, start, end, logpath
+            SELECT id, name, command, status, start, end, logpath, attempt
             FROM runs
             WHERE id = ?
             """,

--- a/skedulord/demo_seed.py
+++ b/skedulord/demo_seed.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import json
 import random
 import uuid
 from pathlib import Path
@@ -68,20 +69,39 @@ def main() -> None:
             start_text = _isoformat(start)
             end_text = _isoformat(end)
 
+            # Determine attempt count
+            if status == "fail":
+                # Failed runs exhausted retries (3-4 attempts)
+                attempt = random.randint(3, 4)
+            elif random.random() < 0.15:
+                # ~15% of successful runs succeeded after retry
+                attempt = random.randint(2, 3)
+            else:
+                # Most successful runs: first attempt
+                attempt = 1
+
             command = f"python jobs/{'badpyjob.py' if status == 'fail' else 'pyjob.py'}"
             log_path = Path(job_name_path(name)) / f"{start.strftime('%Y-%m-%dT%H-%M-%S')}-{run_id[:6]}.txt"
 
-            _write_log(
-                log_path,
-                [
-                    f"job={name}",
-                    f"run_id={run_id}",
-                    f"status={status}",
-                    f"duration={duration}s",
-                    f"command={command}",
-                    "Log output is synthetic for demo purposes.",
-                ],
-            )
+            # Generate log content with attempt JSON entries (matching job.py format)
+            log_lines = []
+            attempt_time = start
+            for i in range(1, attempt + 1):
+                info = {
+                    "name": name,
+                    "command": command,
+                    "run_id": run_id[:8],
+                    "attempt": i,
+                    "timestamp": str(attempt_time),
+                }
+                log_lines.append(json.dumps(info))
+                if i < attempt:
+                    log_lines.append(f"Attempt {i} failed, retrying...")
+                    attempt_time += dt.timedelta(seconds=random.randint(5, 30))
+                else:
+                    log_lines.append("Log output is synthetic for demo purposes.")
+
+            _write_log(log_path, log_lines)
 
             insert_run(
                 run_id=run_id,
@@ -91,6 +111,7 @@ def main() -> None:
                 start=start_text,
                 end=end_text,
                 logpath=str(log_path),
+                attempt=attempt,
             )
 
 

--- a/skedulord/job.py
+++ b/skedulord/job.py
@@ -31,7 +31,7 @@ class JobRunner:
         while not stop:
             log_command = " ".join(command) if isinstance(command, list) else command
             info = {"name": name, "command": log_command, "run_id": run_id, "attempt": tries, "timestamp": str(dt.datetime.now())}
-            self.file.writelines([json.dumps(info), "\n"])            
+            self.file.writelines([json.dumps(info), "\n"])
             output = subprocess.run(
                 command,
                 cwd=str(pathlib.Path().cwd()),
@@ -50,7 +50,8 @@ class JobRunner:
                     stop = True
                 else:
                     time.sleep(self.wait)
-        return "fail" if tries > self.retry else "success"
+        status = "fail" if tries > self.retry else "success"
+        return status, tries
 
     def run(self):
         """
@@ -58,7 +59,7 @@ class JobRunner:
         """
         run_id = str(uuid.uuid4())[:8]
         start_time = self.start_time
-        status = self._attempt_cmd(command=self._cmd_tokens(), name=self.name, run_id=run_id)
+        status, attempts = self._attempt_cmd(command=self._cmd_tokens(), name=self.name, run_id=run_id)
         endtime = str(dt.datetime.now())[:19]
         job_name_path(self.name).mkdir(parents=True, exist_ok=True)
         logpath = str(job_name_path(self.name) / f"{start_time}.txt")
@@ -79,6 +80,7 @@ class JobRunner:
             start=start_time.replace("T", " "),
             end=endtime,
             logpath=logpath,
+            attempt=attempts,
         )
         self.file.close()
 

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -27,17 +27,18 @@ const MAX_RECENT_RUNS = 20;
 const RUNS_PER_PAGE = 25;
 const AUTH_STORAGE_KEY = "skedulord_basic_auth";
 
-function statusColor(status: string) {
+function statusColor(status: string, attempt: number = 1) {
+  if (status === "success" && attempt > 1) return "bg-amber-400";
   if (status === "success") return "bg-emerald-500";
   if (status === "fail") return "bg-rose-500";
   return "bg-amber-400";
 }
 
-function StatusPill({ status }: { status: string }) {
+function StatusPill({ status, attempt = 1 }: { status: string; attempt?: number }) {
   return (
     <span className="inline-flex items-center gap-2 rounded-full bg-white/70 px-3 py-1 text-xs font-semibold text-ink shadow-sm dark:bg-slate-900/70 dark:text-slate-100">
-      <span className={`h-2 w-2 rounded-full ${statusColor(status)}`} />
-      {status}
+      <span className={`h-2 w-2 rounded-full ${statusColor(status, attempt)}`} />
+      {status}{attempt > 1 ? ` (${attempt} attempts)` : ""}
     </span>
   );
 }
@@ -103,7 +104,7 @@ function RunBars({
         const height = maxDuration
           ? Math.max(minHeight, Math.round((duration / maxDuration) * maxHeight))
           : minHeight;
-        const label = `Run ${run.id.slice(0, 8)} · ${formatDuration(duration)} · ${run.status}`;
+        const label = `Run ${run.id.slice(0, 8)} · ${formatDuration(duration)} · ${run.status}${run.attempt > 1 ? ` (${run.attempt} attempts)` : ""}`;
         const isHighlighted = highlightRunId === run.id;
 
         return (
@@ -111,8 +112,9 @@ function RunBars({
             key={run.id}
             type="button"
             className={`group relative ${barWidth} rounded-full ${statusColor(
-              run.status
-            )} transition ${interactive ? "cursor-pointer" : "cursor-default"} hover:-translate-y-0.5 hover:shadow-soft focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ink ${
+              run.status,
+              run.attempt
+            )} transition-transform ${interactive ? "cursor-pointer" : "cursor-default"} hover:-translate-y-0.5 hover:shadow-soft focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ink ${
               isHighlighted
                 ? "ring-2 ring-ink/40 ring-offset-2 ring-offset-white/80 dark:ring-white/40 dark:ring-offset-slate-900/70"
                 : ""
@@ -1331,11 +1333,11 @@ export default function App() {
                                 <span>{job.runs.length} runs in view</span>
                                 {detailRun ? (
                                   <span className="flex items-center gap-1">
-                                    <span className={`h-1.5 w-1.5 rounded-full ${statusColor(detailRun.status)}`} />
+                                    <span className={`h-1.5 w-1.5 rounded-full ${statusColor(detailRun.status, detailRun.attempt)}`} />
                                     {hoveredForJob || focusedForJob ? "Run" : "Last run"}{" "}
                                     {formatDuration(getDurationMs(detailRun))}
                                     {hoveredForJob || focusedForJob
-                                      ? ` · ${detailRun.id.slice(0, 6)} · ${detailRun.status}`
+                                      ? ` · ${detailRun.id.slice(0, 6)} · ${detailRun.status}${detailRun.attempt > 1 ? ` (${detailRun.attempt} attempts)` : ""}`
                                       : ""}
                                   </span>
                                 ) : null}
@@ -1415,7 +1417,7 @@ export default function App() {
                         F
                       </span>
                     </button>
-                    {selectedJobData.latest ? <StatusPill status={selectedJobData.latest.status} /> : null}
+                    {selectedJobData.latest ? <StatusPill status={selectedJobData.latest.status} attempt={selectedJobData.latest.attempt} /> : null}
                   </div>
                 </div>
 
@@ -1472,7 +1474,7 @@ export default function App() {
                                 <span className="text-xs text-ink/60 dark:text-slate-300">
                                   {formatDuration(getDurationMs(run))}
                                 </span>
-                                <StatusPill status={run.status} />
+                                <StatusPill status={run.status} attempt={run.attempt} />
                                 <span className="rounded-full border border-ink/10 px-2 py-0.5 text-[11px] font-semibold text-ink/50 dark:border-white/10 dark:text-slate-300">
                                   Logs
                                 </span>

--- a/webapp/src/api.ts
+++ b/webapp/src/api.ts
@@ -8,6 +8,7 @@ export interface RunEntry {
   start: string;
   end: string;
   logpath: string;
+  attempt: number;
 }
 
 export class ApiError extends Error {


### PR DESCRIPTION
## Summary
Added `attempt` field to track job retry counts. Amber bars now distinguish "success after retry" runs in the dashboard, showing which jobs succeeded after initial failures. Demo data includes realistic retry distribution (failed runs: 3-4 attempts, successful runs: mostly 1 attempt with ~15% requiring retries).

## Changes
- Database: Added `attempt` column to runs table
- Backend: Store actual retry count from job execution
- Frontend: Color-code bars (amber for retried success) and display attempt count
- Demo data: Generate runs with varied attempt counts reflecting real retry patterns

🤖 Generated with Claude Code