### PR TITLE
Add command to quickly add jobs to schedule config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [3.0.1] - 2025-01-27
+
+### Added
+
+- New `skedulord add` command to quickly add jobs to the schedule config file
+  - Point to a script file and provide a cron expression
+  - Auto-generates job name from filename (customizable with `--name`)
+  - Validates file and config existence
+  - Prevents duplicate job names
+
+### Changed
+
+- Removed outdated VITE_* warning comment from init template
+
+## [3.0.0] - Previous Release
+
+Initial 3.x release with FastAPI backend, React webapp, and SQLite storage.

--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,10 @@ reset-big:
 	python -m skedulord run badpyjob "python jobs/badpyjob.py" --retry 3 --wait 1
 	python -m skedulord run another-pyjob "python jobs/pyjob.py" --retry 1 --wait 0
 
-pypi:
+pypi: test
 	rm -rf dist
 	uv build
-	twine upload dist/*
+	uv publish
 
 demo-reset:
 	uv run python -m skedulord wipe disk --really --yes

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,7 +24,7 @@ Options:
   --help           Show this message and exit.
 ```
 
-## `schedule`  
+## `schedule`
 
 Set (or reset) cron jobs based on config.
 
@@ -34,6 +34,21 @@ Arguments:
 
 Options:
   --help  Show this message and exit.
+```
+
+## `add`
+
+Add a job to the schedule config file.
+
+```text
+Arguments:
+  FILE  The file/command to schedule.  [required]
+
+Options:
+  -c, --cron TEXT    Cron expression (e.g. '0 * * * *').  [required]
+  -n, --name TEXT    Job name (defaults to filename).
+  -f, --config PATH  Path to schedule.yml file.  [default: schedule.yml]
+  --help             Show this message and exit.
 ```
 
 ## `history`   

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skedulord"
-version = "3.0.0"
+version = "3.0.1"
 description = "A tool that automates scheduling and logging of jobs."
 readme = "readme.md"
 requires-python = ">=3.9"

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ Options:
 
 Commands:
   schedule  Set (or reset) cron jobs based on config.
+  add       Add a job to the schedule config file.
   run       Run a single command, which is logged by skedulord.
   history   Shows a table with job status.
   init      Initialize a starter .env, schedule.yml, and sqlite database.

--- a/skedulord/__main__.py
+++ b/skedulord/__main__.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Union
 
 import typer
+import yaml
 from rich import print
 from rich.table import Table
 from clumper import Clumper
@@ -153,7 +154,6 @@ def init(
     env_contents = "\n".join(
         [
             "# Skedulord environment (edit as needed).",
-            "# WARNING: never put secrets in frontend VITE_* variables.",
             "SKEDULORD_NO_AUTH=0",
             "SKEDULORD_EXAMPLE_MESSAGE=hello from skedulord",
             "",
@@ -236,6 +236,54 @@ def schedule(
 ):
     """Set (or reset) cron jobs based on config."""
     Cron(config).set_new_cron()
+
+
+@app.command()
+def add(
+    file: Path = typer.Argument(..., help="The file/command to schedule."),
+    cron: str = typer.Option(..., "--cron", "-c", help="Cron expression (e.g. '0 * * * *')."),
+    name: str = typer.Option(None, "--name", "-n", help="Job name (defaults to filename)."),
+    config: Path = typer.Option(
+        Path("schedule.yml"),
+        "--config",
+        "-f",
+        help="Path to schedule.yml file.",
+    ),
+):
+    """Add a job to the schedule config file."""
+    file = file.expanduser().resolve()
+    config = config.expanduser().resolve()
+
+    if not file.exists():
+        print(f"[red]File not found: {file}[/]")
+        raise typer.Exit(code=1)
+
+    if not config.exists():
+        print(f"[red]Config file not found: {config}[/]")
+        print("[yellow]Run 'skedulord init' first or specify a config file with --config.[/]")
+        raise typer.Exit(code=1)
+
+    job_name = name if name else file.stem.replace("_", "-").replace(" ", "-")
+
+    with open(config) as f:
+        data = yaml.safe_load(f)
+
+    existing_names = [job["name"] for job in data.get("schedule", [])]
+    if job_name in existing_names:
+        print(f"[red]Job '{job_name}' already exists in {config}.[/]")
+        raise typer.Exit(code=1)
+
+    new_job = {
+        "name": job_name,
+        "command": str(file),
+        "cron": cron,
+    }
+    data["schedule"].append(new_job)
+
+    with open(config, "w") as f:
+        yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+
+    print(f"[green]Added job '{job_name}' to {config}.[/]")
 
 
 @app.command()

--- a/tests/test_add_command.py
+++ b/tests/test_add_command.py
@@ -1,0 +1,92 @@
+import yaml
+from typer.testing import CliRunner
+
+from skedulord.__main__ import app
+
+
+def test_add_job_to_schedule(tmp_path):
+    schedule_path = tmp_path / "schedule.yml"
+    schedule_path.write_text("user: testuser\nschedule: []\n", encoding="utf8")
+    script_path = tmp_path / "my_script.py"
+    script_path.write_text("print('hello')\n", encoding="utf8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["add", str(script_path), "--cron", "0 * * * *", "--config", str(schedule_path)],
+    )
+
+    assert result.exit_code == 0
+    assert "Added job 'my-script'" in result.output
+
+    data = yaml.safe_load(schedule_path.read_text(encoding="utf8"))
+    assert len(data["schedule"]) == 1
+    assert data["schedule"][0]["name"] == "my-script"
+    assert data["schedule"][0]["command"] == str(script_path)
+    assert data["schedule"][0]["cron"] == "0 * * * *"
+
+
+def test_add_with_custom_name(tmp_path):
+    schedule_path = tmp_path / "schedule.yml"
+    schedule_path.write_text("user: testuser\nschedule: []\n", encoding="utf8")
+    script_path = tmp_path / "script.py"
+    script_path.write_text("print('hello')\n", encoding="utf8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["add", str(script_path), "--cron", "*/5 * * * *", "--name", "my-custom-job", "--config", str(schedule_path)],
+    )
+
+    assert result.exit_code == 0
+    assert "Added job 'my-custom-job'" in result.output
+
+    data = yaml.safe_load(schedule_path.read_text(encoding="utf8"))
+    assert data["schedule"][0]["name"] == "my-custom-job"
+
+
+def test_add_fails_when_file_not_found(tmp_path):
+    schedule_path = tmp_path / "schedule.yml"
+    schedule_path.write_text("user: testuser\nschedule: []\n", encoding="utf8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["add", str(tmp_path / "nonexistent.py"), "--cron", "0 * * * *", "--config", str(schedule_path)],
+    )
+
+    assert result.exit_code != 0
+    assert "File not found" in result.output
+
+
+def test_add_fails_when_config_not_found(tmp_path):
+    script_path = tmp_path / "script.py"
+    script_path.write_text("print('hello')\n", encoding="utf8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["add", str(script_path), "--cron", "0 * * * *", "--config", str(tmp_path / "missing.yml")],
+    )
+
+    assert result.exit_code != 0
+    assert "Config file not found" in result.output
+
+
+def test_add_fails_when_job_name_exists(tmp_path):
+    schedule_path = tmp_path / "schedule.yml"
+    schedule_path.write_text(
+        "user: testuser\nschedule:\n  - name: my-script\n    command: /old/path\n    cron: '0 0 * * *'\n",
+        encoding="utf8",
+    )
+    script_path = tmp_path / "my_script.py"
+    script_path.write_text("print('hello')\n", encoding="utf8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["add", str(script_path), "--cron", "0 * * * *", "--config", str(schedule_path)],
+    )
+
+    assert result.exit_code != 0
+    assert "already exists" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -1297,7 +1297,7 @@ wheels = [
 
 [[package]]
 name = "skedulord"
-version = "3.0.0"
+version = "3.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "clumper" },


### PR DESCRIPTION
Adds a new `skedulord add` command for registering jobs with cron expressions directly from the CLI. Users can point to a script file and supply a cron time expression to immediately add the job to the schedule config.

The command includes:
- Job name auto-generation from filename (customizable with --name)
- Validation that file and config exist
- Duplicate job name detection
- Proper YAML serialization

Also removes the outdated VITE_* warning comment from the init template.

🤖 Generated with Claude Code