### PR TITLE
Add rm command and --schedule flag to add/rm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.2] - 2025-01-27
+
+### Added
+
+- New `skedulord rm` command to remove jobs from the schedule config file
+- `--schedule/--no-schedule` flag on `add` and `rm` commands to update crontab automatically (default: on)
+
+### Changed
+
+- `skedulord schedule` now defaults to `schedule.yml` in the current directory (no argument required)
+
 ## [3.0.1] - 2025-01-27
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Coding Preferences
+
+- Only use lazy imports (imports inside functions) when absolutely necessary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skedulord"
-version = "3.0.1"
+version = "3.0.2"
 description = "A tool that automates scheduling and logging of jobs."
 readme = "readme.md"
 requires-python = ">=3.9"

--- a/skedulord/__main__.py
+++ b/skedulord/__main__.py
@@ -231,10 +231,14 @@ def run(
 @app.command()
 def schedule(
     config: Path = typer.Argument(
-        ..., help="The config file containing the schedule.", exists=True
+        Path("schedule.yml"), help="The config file containing the schedule."
     )
 ):
     """Set (or reset) cron jobs based on config."""
+    config = config.expanduser().resolve()
+    if not config.exists():
+        print(f"[red]Config file not found: {config}[/]")
+        raise typer.Exit(code=1)
     Cron(config).set_new_cron()
 
 
@@ -248,6 +252,12 @@ def add(
         "--config",
         "-f",
         help="Path to schedule.yml file.",
+    ),
+    update_schedule: bool = typer.Option(
+        True,
+        "--schedule/--no-schedule",
+        "-s",
+        help="Update crontab after adding job.",
     ),
 ):
     """Add a job to the schedule config file."""
@@ -284,6 +294,53 @@ def add(
         yaml.dump(data, f, default_flow_style=False, sort_keys=False)
 
     print(f"[green]Added job '{job_name}' to {config}.[/]")
+
+    if update_schedule:
+        Cron(config).set_new_cron()
+        print("[green]Crontab updated.[/]")
+
+
+@app.command()
+def rm(
+    name: str = typer.Argument(..., help="The job name to remove."),
+    config: Path = typer.Option(
+        Path("schedule.yml"),
+        "--config",
+        "-f",
+        help="Path to schedule.yml file.",
+    ),
+    update_schedule: bool = typer.Option(
+        True,
+        "--schedule/--no-schedule",
+        "-s",
+        help="Update crontab after removing job.",
+    ),
+):
+    """Remove a job from the schedule config file."""
+    config = config.expanduser().resolve()
+
+    if not config.exists():
+        print(f"[red]Config file not found: {config}[/]")
+        raise typer.Exit(code=1)
+
+    with open(config) as f:
+        data = yaml.safe_load(f)
+
+    existing_names = [job["name"] for job in data.get("schedule", [])]
+    if name not in existing_names:
+        print(f"[red]Job '{name}' not found in {config}.[/]")
+        raise typer.Exit(code=1)
+
+    data["schedule"] = [job for job in data["schedule"] if job["name"] != name]
+
+    with open(config, "w") as f:
+        yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+
+    print(f"[green]Removed job '{name}' from {config}.[/]")
+
+    if update_schedule:
+        Cron(config).set_new_cron()
+        print("[green]Crontab updated.[/]")
 
 
 @app.command()

--- a/tests/test_add_command.py
+++ b/tests/test_add_command.py
@@ -13,7 +13,7 @@ def test_add_job_to_schedule(tmp_path):
     runner = CliRunner()
     result = runner.invoke(
         app,
-        ["add", str(script_path), "--cron", "0 * * * *", "--config", str(schedule_path)],
+        ["add", str(script_path), "--cron", "0 * * * *", "--config", str(schedule_path), "--no-schedule"],
     )
 
     assert result.exit_code == 0
@@ -35,7 +35,7 @@ def test_add_with_custom_name(tmp_path):
     runner = CliRunner()
     result = runner.invoke(
         app,
-        ["add", str(script_path), "--cron", "*/5 * * * *", "--name", "my-custom-job", "--config", str(schedule_path)],
+        ["add", str(script_path), "--cron", "*/5 * * * *", "--name", "my-custom-job", "--config", str(schedule_path), "--no-schedule"],
     )
 
     assert result.exit_code == 0
@@ -90,3 +90,48 @@ def test_add_fails_when_job_name_exists(tmp_path):
 
     assert result.exit_code != 0
     assert "already exists" in result.output
+
+
+def test_rm_job_from_schedule(tmp_path):
+    schedule_path = tmp_path / "schedule.yml"
+    schedule_path.write_text(
+        "user: testuser\nschedule:\n  - name: my-job\n    command: /path/to/script.py\n    cron: '0 * * * *'\n",
+        encoding="utf8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["rm", "my-job", "--config", str(schedule_path), "--no-schedule"],
+    )
+
+    assert result.exit_code == 0
+    assert "Removed job 'my-job'" in result.output
+
+    data = yaml.safe_load(schedule_path.read_text(encoding="utf8"))
+    assert len(data["schedule"]) == 0
+
+
+def test_rm_fails_when_job_not_found(tmp_path):
+    schedule_path = tmp_path / "schedule.yml"
+    schedule_path.write_text("user: testuser\nschedule: []\n", encoding="utf8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["rm", "nonexistent-job", "--config", str(schedule_path)],
+    )
+
+    assert result.exit_code != 0
+    assert "not found" in result.output
+
+
+def test_rm_fails_when_config_not_found(tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["rm", "some-job", "--config", str(tmp_path / "missing.yml")],
+    )
+
+    assert result.exit_code != 0
+    assert "Config file not found" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -1297,7 +1297,7 @@ wheels = [
 
 [[package]]
 name = "skedulord"
-version = "3.0.1"
+version = "3.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "clumper" },


### PR DESCRIPTION
## Summary

Add new `skedulord rm` command and `--schedule/--no-schedule` flag to both `add` and `rm` commands. The schedule flag (default: on) automatically updates the crontab after modifying jobs. Also make `skedulord schedule` default to schedule.yml in the current directory.

## Changes

- New `skedulord rm` command to remove jobs
- `--schedule` flag on `add` and `rm` (default: on)
- `skedulord schedule` defaults to schedule.yml
- Updated tests and version to 3.0.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)