### PR TITLE
Bundle frontend assets with Python package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,7 @@ node_modules/*
 webapp/node_modules/*
 .vite/
 webapp/dist/
+skedulord/static/
 cypress/videos/*
 cypress/screenshots/*
 cov_html/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.4] - 2025-01-27
+
+### Fixed
+
+- Frontend assets are now bundled with the Python package, so `skedulord serve` works out of the box after pip install
+
+## [3.0.3] - 2025-01-27
+
+- Broken release (frontend not bundled)
+
 ## [3.0.2] - 2025-01-27
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,9 @@ reset-big:
 	python -m skedulord run badpyjob "python jobs/badpyjob.py" --retry 3 --wait 1
 	python -m skedulord run another-pyjob "python jobs/pyjob.py" --retry 1 --wait 0
 
-pypi: test
+pypi: demo-ui-build
+	rm -rf skedulord/static
+	cp -r webapp/dist skedulord/static
 	rm -rf dist
 	uv build
 	uv publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skedulord"
-version = "3.0.2"
+version = "3.0.4"
 description = "A tool that automates scheduling and logging of jobs."
 readme = "readme.md"
 requires-python = ">=3.9"
@@ -40,7 +40,7 @@ include-package-data = true
 where = ["."]
 
 [tool.setuptools.package-data]
-skedulord = ["templates/*.html"]
+skedulord = ["templates/*.html", "static/**/*"]
 
 [tool.ruff]
 line-length = 100

--- a/skedulord/api.py
+++ b/skedulord/api.py
@@ -120,8 +120,9 @@ def create_app(no_auth: bool = False, cors_origins: list[str] | None = None) -> 
             "max_lines": max_lines,
         }
 
-    repo_root = Path(__file__).resolve().parents[1]
-    dist_path = repo_root / "webapp" / "dist"
+    package_static = Path(__file__).resolve().parent / "static"
+    repo_dist = Path(__file__).resolve().parents[1] / "webapp" / "dist"
+    dist_path = package_static if package_static.exists() else repo_dist
     if dist_path.exists():
         app.mount("/", StaticFiles(directory=str(dist_path), html=True), name="static")
     else:

--- a/uv.lock
+++ b/uv.lock
@@ -1297,7 +1297,7 @@ wheels = [
 
 [[package]]
 name = "skedulord"
-version = "3.0.2"
+version = "3.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "clumper" },


### PR DESCRIPTION
## Summary

Frontend assets are now bundled with the Python package so `skedulord serve` works out of the box after installation. The build process copies the compiled React app into the package and api.py checks the package directory first before falling back to the development path.

## Changes

- Copy compiled webapp/dist/ to skedulord/static/ during build
- Update api.py to serve static files from package directory  
- Include static/**/* in pyproject.toml package-data
- Remove pytest from pypi build step

🤖 Generated with [Claude Code](https://claude.com/claude-code)