### PR TITLE
Hide sign out button when --no-auth flag is used

### DIFF
--- a/skedulord/api.py
+++ b/skedulord/api.py
@@ -47,7 +47,7 @@ def create_app(no_auth: bool = False, cors_origins: list[str] | None = None) -> 
         if no_auth:
             return await call_next(request)
         path = request.url.path
-        if path in ("/api/health",):
+        if path in ("/api/health", "/api/config"):
             return await call_next(request)
         requires_auth = path.startswith("/api") or path.startswith("/docs") or path == "/openapi.json"
         if not requires_auth:
@@ -66,6 +66,10 @@ def create_app(no_auth: bool = False, cors_origins: list[str] | None = None) -> 
     @app.get("/api/health")
     def health() -> dict:
         return {"status": "ok"}
+
+    @app.get("/api/config")
+    def config() -> dict:
+        return {"no_auth": no_auth}
 
     @app.get("/api")
     def api_root() -> dict:

--- a/tests/test_api_security.py
+++ b/tests/test_api_security.py
@@ -70,3 +70,25 @@ def test_logs_endpoint_limits_lines(clean_slate, tmp_path):
     assert payload["content"] == "line-3\nline-4"
     assert payload["truncated"] is True
     assert payload["max_lines"] == 2
+
+
+def test_config_endpoint_returns_no_auth_false_by_default(clean_slate):
+    client = TestClient(create_app(no_auth=False))
+    response = client.get("/api/config")
+    assert response.status_code == 200
+    assert response.json() == {"no_auth": False}
+
+
+def test_config_endpoint_returns_no_auth_true_when_enabled(clean_slate):
+    client = TestClient(create_app(no_auth=True))
+    response = client.get("/api/config")
+    assert response.status_code == 200
+    assert response.json() == {"no_auth": True}
+
+
+def test_config_endpoint_accessible_without_auth(clean_slate):
+    # When auth is required, /api/config should still be accessible
+    client = TestClient(create_app(no_auth=False))
+    # No auth headers provided
+    response = client.get("/api/config")
+    assert response.status_code == 200

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -17,8 +17,10 @@ import {
 import {
   ApiError,
   clearAuthHeader,
+  detectNoAuthMode,
   fetchLog,
   fetchRuns,
+  isNoAuthMode,
   isStaticMode,
   setAuthHeader,
   type RunEntry
@@ -341,6 +343,7 @@ export default function App() {
     setLoading(true);
     setError(null);
     try {
+      await detectNoAuthMode();
       const data = await fetchRuns({ limit: 500 });
       setRuns(data);
       setAuthRequired(false);
@@ -1256,7 +1259,7 @@ export default function App() {
               Refresh
               <span className={headerKeycapClass}>R</span>
             </button>
-            {!isStaticMode() && (
+            {!isStaticMode() && !isNoAuthMode() && (
               <button
                 onClick={handleLogout}
                 className={headerButtonClass}

--- a/webapp/src/api.ts
+++ b/webapp/src/api.ts
@@ -27,8 +27,33 @@ let authHeader: string | null = null;
 let staticModeDetected: boolean | null = null;
 let cachedRuns: RunEntry[] | null = null;
 
+// No-auth mode is detected from server config
+let noAuthModeDetected: boolean | null = null;
+
 export function isStaticMode(): boolean {
   return staticModeDetected === true;
+}
+
+export function isNoAuthMode(): boolean {
+  return noAuthModeDetected === true;
+}
+
+export async function detectNoAuthMode(): Promise<boolean> {
+  if (noAuthModeDetected !== null) {
+    return noAuthModeDetected;
+  }
+  try {
+    const response = await fetch(`${apiBase}/api/config`);
+    if (response.ok) {
+      const data = await response.json();
+      noAuthModeDetected = data.no_auth === true;
+    } else {
+      noAuthModeDetected = false;
+    }
+  } catch {
+    noAuthModeDetected = false;
+  }
+  return noAuthModeDetected;
 }
 
 function authHeaders() {


### PR DESCRIPTION
## Summary

Adds `/api/config` endpoint to expose the no_auth setting. The frontend now detects this and conditionally hides the sign out button, avoiding confusion when authentication is disabled. This follows the existing pattern used for static mode detection.

## Changes

- Backend: Added `/api/config` endpoint and updated middleware to allow unauthenticated access
- Frontend: Added `detectNoAuthMode()` and `isNoAuthMode()` functions, called on app load
- Sign out button now hidden when no-auth mode is active
- Added 3 tests for the new config endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)