### PR TITLE
Remove log truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.5] - 2025-01-27
+
+### Changed
+
+- Removed log truncation - full log content is now displayed instead of being limited to 2000 lines
+
 ## [3.0.4] - 2025-01-27
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skedulord"
-version = "3.0.4"
+version = "3.0.5"
 description = "A tool that automates scheduling and logging of jobs."
 readme = "readme.md"
 requires-python = ">=3.9"

--- a/skedulord/api.py
+++ b/skedulord/api.py
@@ -98,7 +98,7 @@ def create_app(no_auth: bool = False, cors_origins: list[str] | None = None) -> 
         return dict(row)
 
     @app.get("/api/logs/{run_id}")
-    def get_log(run_id: str, max_lines: int = 2000) -> dict:
+    def get_log(run_id: str) -> dict:
         row = fetch_run(run_id)
         if not row:
             raise HTTPException(status_code=404, detail="Run not found")
@@ -111,17 +111,9 @@ def create_app(no_auth: bool = False, cors_origins: list[str] | None = None) -> 
             raise HTTPException(status_code=403, detail="Log file is outside the skedulord data directory")
         if not logpath.exists():
             raise HTTPException(status_code=404, detail="Log file not found")
-        if max_lines <= 0:
-            raise HTTPException(status_code=400, detail="max_lines must be positive")
-        lines = logpath.read_text().splitlines()
-        truncated = len(lines) > max_lines
-        if truncated:
-            lines = lines[-max_lines:]
         return {
             "logpath": str(resolved_logpath),
-            "content": "\n".join(lines),
-            "truncated": truncated,
-            "max_lines": max_lines,
+            "content": logpath.read_text(),
         }
 
     package_static = Path(__file__).resolve().parent / "static"

--- a/skedulord/dashboard.py
+++ b/skedulord/dashboard.py
@@ -94,24 +94,16 @@ def export_static_site(output_dir: Path) -> None:
         run_id = run["id"]
         logpath = run["logpath"]
         log_content = ""
-        truncated = False
 
         if logpath and Path(logpath).exists():
             try:
-                lines = Path(logpath).read_text().split("\n")
-                max_lines = 2000
-                if len(lines) > max_lines:
-                    lines = lines[:max_lines]
-                    truncated = True
-                log_content = "\n".join(lines)
+                log_content = Path(logpath).read_text()
             except Exception:
                 log_content = f"Error reading log file: {logpath}"
 
         log_data = {
             "logpath": logpath,
             "content": log_content,
-            "truncated": truncated,
-            "max_lines": 2000,
         }
         (logs_dir / f"{run_id}.json").write_text(json.dumps(log_data, indent=2))
 

--- a/tests/test_api_security.py
+++ b/tests/test_api_security.py
@@ -48,15 +48,15 @@ def test_cors_enabled_via_env(clean_slate, monkeypatch):
     assert response.headers.get("access-control-allow-origin") == "http://localhost:5173"
 
 
-def test_logs_endpoint_limits_lines(clean_slate, tmp_path):
-    logpath = skedulord_path() / "long" / "long.log"
+def test_logs_endpoint_returns_full_content(clean_slate):
+    logpath = skedulord_path() / "test" / "test.log"
     logpath.parent.mkdir(parents=True, exist_ok=True)
-    logpath.write_text("\n".join([f"line-{idx}" for idx in range(5)]))
+    logpath.write_text("line-0\nline-1\nline-2")
 
     insert_run(
-        run_id="run-long",
-        name="long",
-        command="echo long",
+        run_id="run-test",
+        name="test",
+        command="echo test",
         status="success",
         start="2024-01-01 00:00:00",
         end="2024-01-01 00:00:01",
@@ -64,12 +64,11 @@ def test_logs_endpoint_limits_lines(clean_slate, tmp_path):
     )
 
     client = TestClient(create_app(no_auth=True))
-    response = client.get("/api/logs/run-long", params={"max_lines": 2})
+    response = client.get("/api/logs/run-test")
     assert response.status_code == 200
     payload = response.json()
-    assert payload["content"] == "line-3\nline-4"
-    assert payload["truncated"] is True
-    assert payload["max_lines"] == 2
+    assert payload["content"] == "line-0\nline-1\nline-2"
+    assert "logpath" in payload
 
 
 def test_config_endpoint_returns_no_auth_false_by_default(clean_slate):

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -82,8 +82,6 @@ def test_export_creates_log_files(clean_start_with_runs):
             log_data = json.loads(log_file.read_text())
             assert "logpath" in log_data
             assert "content" in log_data
-            assert "truncated" in log_data
-            assert "max_lines" in log_data
 
 
 def test_export_empty_database(empty_start):


### PR DESCRIPTION
Stop truncating logs at 2000 lines. For cronjob logs, full content should be displayed.

## Changes
- Remove max_lines parameter from API endpoint
- Simplify log loading to read full file content
- Remove truncation logic from backend and static export
- Update tests to reflect no truncation

Closes the issue where long error messages were cut off in the frontend.