### PR TITLE
Simplify local development: disable auth by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ demo-seed:
 
 
 demo-run: demo-reset demo-seed demo-ui-build
-	uv run python -m skedulord serve --reload
+	uv run python -m skedulord serve --reload --no-auth
 
 demo-run-dev: demo-reset demo-seed
 	SKEDULORD_CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173 \

--- a/contrib.md
+++ b/contrib.md
@@ -2,15 +2,6 @@
 
 ## Local demo server
 
-This repo ships with a small end‑to‑end demo that seeds a few runs, starts the API, and lets
-you launch the React webapp against it.
-
-### Prerequisites
-
-- Python 3.9+
-- `uv`
-- Node.js 18+
-
 ### Quickstart
 
 ```bash
@@ -18,16 +9,26 @@ make demo-install
 make demo-run
 ```
 
-This will:
+This starts the API at `http://127.0.0.1:8000` with demo data and no authentication.
 
-- wipe `~/.skedulord` state
-- run a handful of demo jobs (including a failing one)
-- build the webapp and serve it from FastAPI at `http://127.0.0.1:8000` (API is under `/api/*`, docs at `/docs`)
-
-In another terminal, you can also run the webapp dev server:
+Run the webapp dev server in another terminal:
 
 ```bash
-make demo-web
+cd webapp && npm install && npm run dev
+```
+
+### Testing with authentication
+
+To test authentication:
+
+```bash
+uv run python -m skedulord serve --reload
+```
+
+Add a user:
+
+```bash
+uv run python -m skedulord users add --username myuser
 ```
 
 ### Cleanup
@@ -35,8 +36,3 @@ make demo-web
 ```bash
 make demo-clean
 ```
-
-## Notes
-
-- The API is read‑only for now; job triggering will require auth.
-- Demo jobs are defined in `jobs/` and run via `uv run python`.

--- a/readme.md
+++ b/readme.md
@@ -149,3 +149,5 @@ python -m skedulord serve
 
 The frontend lives in `webapp/` and can be run via `npm install` + `npm run dev`.
 If you run `npm run build`, the API will serve the built app from `webapp/dist`.
+
+For local development with demo data, see the [contributing guide](contrib.md).

--- a/uv.lock
+++ b/uv.lock
@@ -1297,7 +1297,7 @@ wheels = [
 
 [[package]]
 name = "skedulord"
-version = "3.0.5"
+version = "3.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "clumper" },


### PR DESCRIPTION
## Summary

Eliminates authentication friction during local development by disabling auth in `make demo-run` by default. Developers can now immediately test the UI without managing credentials.

Streamlined contributor documentation by removing verbose explanations and focusing on essential setup steps. Added reference to contributing guide from main readme.

## Changes

- Add `--no-auth` flag to `demo-run` make target
- Clean up and simplify contrib.md with clearer structure
- Link to contrib.md from readme.md webapp section

🤖 Generated with [Claude Code](https://claude.com/claude-code)