### PR TITLE
Show job run datetime instead of duration on overview

### DIFF
--- a/tests/test_cron_parsing.py
+++ b/tests/test_cron_parsing.py
@@ -7,17 +7,14 @@ checks = [
     {
         "name": "foo",
         "command": "python foobar.py",
-        "arguments": {"hello": "world"},
         "expected": "python foobar.py --hello world",
     },
     {
         "name": "foo",
-        "command": "python foobar.py",
         "arguments": {"hello": "world", "one": 1},
         "expected": "python foobar.py --hello world --one 1",
     },
     {
-        "name": "download",
         "command": "python -m gitwit download apache/airflow",
         "expected": "python -m gitwit download apache/airflow",
     }

--- a/tests/test_cron_parsing.py
+++ b/tests/test_cron_parsing.py
@@ -7,14 +7,17 @@ checks = [
     {
         "name": "foo",
         "command": "python foobar.py",
+        "arguments": {"hello": "world"},
         "expected": "python foobar.py --hello world",
     },
     {
         "name": "foo",
+        "command": "python foobar.py",
         "arguments": {"hello": "world", "one": 1},
         "expected": "python foobar.py --hello world --one 1",
     },
     {
+        "name": "download",
         "command": "python -m gitwit download apache/airflow",
         "expected": "python -m gitwit download apache/airflow",
     }

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -63,6 +63,18 @@ function formatDuration(ms: number) {
   return `${hours}h`;
 }
 
+function formatRunTime(isoString: string) {
+  const date = new Date(Date.parse(isoString));
+  if (!Number.isFinite(date.getTime())) return "unknown";
+  return date.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true
+  });
+}
+
 function filenameOnly(path?: string | null) {
   if (!path) return "";
   const normalized = path.replace(/\\/g, "/");
@@ -1341,7 +1353,7 @@ export default function App() {
                                   <span className="flex items-center gap-1">
                                     <span className={`h-1.5 w-1.5 rounded-full ${statusColor(detailRun.status, detailRun.attempt)}`} />
                                     {hoveredForJob || focusedForJob ? "Run" : "Last run"}{" "}
-                                    {formatDuration(getDurationMs(detailRun))}
+                                    {formatRunTime(detailRun.start)}
                                     {hoveredForJob || focusedForJob
                                       ? ` · ${detailRun.id.slice(0, 6)} · ${detailRun.status}${detailRun.attempt > 1 ? ` (${detailRun.attempt} attempts)` : ""}`
                                       : ""}


### PR DESCRIPTION
## Summary
Changed the overview page to display when jobs ran (e.g., "Mar 10, 2:32 PM") instead of how long they took. This makes it easier to see at a glance which jobs executed recently.

## Changes
- Added `formatRunTime()` utility to convert ISO timestamps to readable datetime format
- Updated the overview job list to show actual run time instead of duration
- Duration display remains on the job detail page and RunBars charts where it's still useful

🤖 Generated with [Claude Code](https://claude.com/claude-code)